### PR TITLE
Make single input array work

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -128,13 +128,13 @@ runs:
         if [ -z "$labels" ]; then
           echo "labels is empty"
         else
-          command+=("--labels=\"$labels\"")
+          command+=("--labels=$labels")
         fi
 
         if [ -z "$excludedLabels" ]; then
           echo "excludedLabels is empty"
         else
-          command+=("--excluded-labels=\"$excludedLabels\"")
+          command+=("--excluded-labels=$excludedLabels")
         fi
 
         if [ -z "$branch" ]; then


### PR DESCRIPTION
By adding `\"` the character was added to the script and was considered part of the label