### PR TITLE
Accidentally removed the command call instead of just removing base64

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -175,7 +175,7 @@ runs:
 
         command+=("--log-console")
 
-        changelog="${command[@]}"
+        changelog=$("${command[@]}")
 
         # Escape the special characters so that multiline output is supported
         changelog="${changelog//'%'/'%25'}"


### PR DESCRIPTION
The command is just getting logged instead of getting executed right now