### PR TITLE
IPFM-1355: Align versions of actions with other repos

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: Cache
-      uses: actions/cache@v2.0.0
+      uses: actions/cache@v3
       with:
         path: .build
         key: ${{ runner.os }}-swift-${{ hashFiles('Package.resolved') }} 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.merged == true && github.head_ref == 'create-release'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: Get app version
       id: get-version
@@ -23,7 +23,7 @@ jobs:
         echo "::set-output name=tag::$tag"
 
     - name: Update tag
-      uses: richardsimko/update-tag@v1
+      uses: scoremedia/update-tag@v2
       with:
         tag_name: "${{ steps.get-version.outputs.tag }}"
       env:
@@ -52,7 +52,7 @@ jobs:
 
     - name: Create Release
       id: create_release
-      uses: ncipollo/release-action@v1
+      uses: scoremedia/release-action@v2
       with:
         tag: "${{ steps.get-version.outputs.tag }}"
         body: |

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
     - name: Check Acccess
-      uses: sushichop/action-repository-permission@v1
+      uses: scoremedia/action-repository-permission@v2 
       with:
         required-permission: admin
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     
     - name: Create branch
       run: git checkout -b create-release
@@ -54,7 +54,7 @@ jobs:
         git push origin create-release --force 
     
     - name: Create PR
-      uses: peter-evans/create-pull-request@v3
+      uses: scorebet/create-pull-request@v5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         branch: create-release


### PR DESCRIPTION
IPFM-1355
----
<!-- Summary of the changes (why we need this) -->
Align action versions between all repositories

Details
----
* Update `actions/checkout` from `v2` to `v3`
* Update `actions/cache` from `v2.0.0` to `v3`
* Replace `richardsimko/update-tag@v1` with `scoremedia/update-tag@v2
* Replace `ncipollo/release-action@v1` with `scoremedia/release-action@v2`
* Replace `sushichop/action-repository-permission@v1` with `scoremedia/action-repository-permission@v2`
* Replace `peter-evans/create-pull-request@v3` with `scorebet/create-pull-request@v5`
`
